### PR TITLE
Update to point to v1.1 of the REST API, bump NPM version

### DIFF
--- a/lib/passport-twitter-token/strategy.js
+++ b/lib/passport-twitter-token/strategy.js
@@ -121,7 +121,7 @@ TwitterTokenStrategy.prototype.authenticate = function(req, options) {
  */
 TwitterTokenStrategy.prototype.userProfile = function(token, tokenSecret, params, done) {
   if (!this._skipExtendedUserProfile) {
-    this._oauth.get('https://api.twitter.com/1/users/show.json?user_id=' + params.user_id, token, tokenSecret, function (err, body, res) {
+    this._oauth.get('https://api.twitter.com/1.1/users/show.json?user_id=' + params.user_id, token, tokenSecret, function (err, body, res) {
       if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
 
       try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-twitter-token",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Twitter token authentication strategy for Passport.",
   "author": { "name": "Nicholas Penree", "email": "nick@penree.com", "url": "http://penree.com" },
   "repository": {


### PR DESCRIPTION
Twitter has disabled access to the v1 endpoint, updating to v1.1. See [https://github.com/jaredhanson/passport-twitter/pull/27](https://github.com/jaredhanson/passport-twitter/pull/27).
