### PR TITLE
Use string instead of integer for id.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,9 +90,14 @@ export default class TwitterTokenStrategy extends OAuthStrategy {
 
       try {
         let json = JSON.parse(body);
+        let profileId = String(json.id);
+        if (json.id_str) {
+          profileId = json.id_str;
+        }
+
         let profile = {
           provider: 'twitter',
-          id: json.id,
+          id: profileId,
           username: json.screen_name,
           displayName: json.name,
           name: {

--- a/src/index.js
+++ b/src/index.js
@@ -90,14 +90,9 @@ export default class TwitterTokenStrategy extends OAuthStrategy {
 
       try {
         let json = JSON.parse(body);
-        let profileId = String(json.id);
-        if (json.id_str) {
-          profileId = json.id_str;
-        }
-
         let profile = {
           provider: 'twitter',
-          id: profileId,
+          id: json.id_str ? json.id_str : String(json.id),
           username: json.screen_name,
           displayName: json.name,
           name: {

--- a/test/fixtures/profile.js
+++ b/test/fixtures/profile.js
@@ -1,5 +1,6 @@
 export default JSON.stringify({
-  id: '1234',
+  id: 710474596655480832,
+  id_str: '710474596655480832',
   screen_name: 'ghaiklor',
   name: 'Eugene Obrezkov',
   profile_image_url_https: 'IMAGE_URL'

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -198,7 +198,7 @@ describe('TwitterTokenStrategy:userProfile', () => {
       if (error) return done(error);
 
       assert.equal(profile.provider, 'twitter');
-      assert.equal(profile.id, '1234');
+      assert.equal(profile.id, '710474596655480832');
       assert.equal(profile.username, 'ghaiklor');
       assert.equal(profile.displayName, 'Eugene Obrezkov');
       assert.deepEqual(profile.photos, [{value: 'IMAGE_URL'}]);


### PR DESCRIPTION
Newly registered twitter users has greater id, than JavaScript can handle.