### PR TITLE
Added support for fetch email

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The `verify` callback must call `done` providing a user to complete authenticati
 In order to identify your application to Twitter, specify the consumer key, consumer secret, and callback URL within `options`.
 The consumer key and secret are obtained by [creating an application](https://dev.twitter.com/apps) at Twitter's [developer](https://dev.twitter.com/) site.
 
+Optional fields:
+ - `includeEmail` - Boolean 
+ - `includeStatus` - Boolean
+ - `includeEntities` - Boolean
+ - `userProfileURL` - Default `https://api.twitter.com/1.1/account/verify_credentials.json`
+ 
 ```javascript
 var TwitterTokenStrategy = require('passport-twitter-token');
 

--- a/test/fixtures/profile.js
+++ b/test/fixtures/profile.js
@@ -3,5 +3,6 @@ export default JSON.stringify({
   id_str: '710474596655480832',
   screen_name: 'ghaiklor',
   name: 'Eugene Obrezkov',
-  profile_image_url_https: 'IMAGE_URL'
+  profile_image_url_https: 'IMAGE_URL',
+  email: 'ghaiklor@gmail.com'
 });

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -5,7 +5,10 @@ import fakeProfile from '../fixtures/profile';
 
 const STRATEGY_CONFIG = {
   consumerKey: '123',
-  consumerSecret: '123'
+  consumerSecret: '123',
+  options: {
+    includeEmail: true
+  }
 };
 
 const BLANK_FUNCTION = () => {
@@ -201,9 +204,11 @@ describe('TwitterTokenStrategy:userProfile', () => {
       assert.equal(profile.id, '710474596655480832');
       assert.equal(profile.username, 'ghaiklor');
       assert.equal(profile.displayName, 'Eugene Obrezkov');
+      assert.equal(profile.emails[0].value, 'ghaiklor@gmail.com');
       assert.deepEqual(profile.photos, [{value: 'IMAGE_URL'}]);
       assert.equal(typeof profile._raw, 'string');
       assert.equal(typeof profile._json, 'object');
+      assert.equal(typeof profile.emails, 'object')
 
       strategy._oauth.get.restore();
 


### PR DESCRIPTION
Changed use profile fetch API to `https://dev.twitter.com/rest/reference/get/account/verify_credentials`
- Added provision to fetch email
- Added provision to fetch status
- Added provision to include entities
